### PR TITLE
fixed index error with Eigen 3.3.7

### DIFF
--- a/src/planner/traj_utils/include/traj_utils/polynomial_traj.h
+++ b/src/planner/traj_utils/include/traj_utils/polynomial_traj.h
@@ -234,7 +234,7 @@ public:
       for (double i = 3; i < order; i += 1)
         for (double j = 3; j < order; j += 1)
         {
-          mat_jerk(i, j) =
+          mat_jerk((size_t)i, (size_t)j) =
               i * (i - 1) * (i - 2) * j * (j - 1) * (j - 2) * pow(ts, i + j - 5) / (i + j - 5);
         }
 


### PR DESCRIPTION
The original code cannot be compiled with Eigen 3.3.7 and raises the following error message
```
error: no match for ‘operator=’ (operand types are ‘Eigen::internal::enable_if<true, Eigen::IndexedView<Eigen::Matrix<double, -1, -1>, double, double> >::type’ {aka ‘Eigen::IndexedView<Eigen::Matrix<double, -1, -1>, double, double>’} and ‘double’)
  238 |               i * (i - 1) * (i - 2) * j * (j - 1) * (j - 2) * pow(ts, i + j - 5) / (i + j - 5);
      |                                                                                              ^
```

The index should be explicitly converted to `size_t`. 